### PR TITLE
Remove citeproc from build

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -16,10 +16,9 @@ jobs:
       - name: Setup R
         uses: r-lib/actions/setup-r@master
 
-      - name: Install pandoc and pandoc citeproc
+      - name: Install pandoc
         run: |
           brew install pandoc
-          brew install pandoc-citeproc
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
Current build is failing 
```
Error: pandoc-citeproc has been disabled because it is deprecated upstream!
```

Removing citeproc from build based on https://github.com/r-lib/actions/issues/220
Let's see if it fixes it.